### PR TITLE
Add subscription fields to User type

### DIFF
--- a/stores/auth.ts
+++ b/stores/auth.ts
@@ -9,6 +9,15 @@ interface User {
   google_id?: string; // Google ID追加（オプション）
   avatar?: string; // プロフィール画像URL追加（オプション）
   social_type?: string; // ソーシャルログインの種類追加（オプション）
+  plan?: "free" | "standard" | "premium";
+  subscription_status?:
+    | "active"
+    | "canceled"
+    | "past_due"
+    | "incomplete"
+    | "incomplete_expired"
+    | "trialing"
+    | "unpaid";
 }
 
 // 認証状態の型定義


### PR DESCRIPTION
## Summary
- extend `User` interface with `plan` and `subscription_status` fields

## Testing
- `npm run build`
- `npm run dev` (started and showed local server URL)


------
https://chatgpt.com/codex/tasks/task_e_6842aea490ec832589f2327476401fe8